### PR TITLE
markdown: use markdown hook to auto fill some char pairs

### DIFF
--- a/bundles/markdown/bundle.el
+++ b/bundles/markdown/bundle.el
@@ -7,3 +7,9 @@
 (add-to-list 'auto-mode-alist '("\\.mdown$" . markdown-mode))
 (add-to-list 'auto-mode-alist '("\\.mdwn$" . markdown-mode))
 (add-to-list 'auto-mode-alist '("\\.text$" . markdown-mode))
+
+(defun e-max-markdown-mode-hook ()
+  (e-max--set-pairs '("(" "{" "[" "\""))
+  (auto-fill-mode 1))
+
+(add-hook 'markdown-mode-hook 'e-max-markdown-mode-hook)


### PR DESCRIPTION
I would like to use some default auto fill pairs, like in the org-mode bundle.

thanks
