### PR TITLE
set-default-font function is obsolete since emacs v23.1

### DIFF
--- a/lib/platforms/mac.el
+++ b/lib/platforms/mac.el
@@ -16,7 +16,7 @@
 (prefer-coding-system 'utf-8)
 
 ;; custom place to save customizations
-(set-default-font "-apple-consolas-medium-r-normal--13-130-72-72-m-130-iso10646-1")
+(set-frame-font "-apple-consolas-medium-r-normal--13-130-72-72-m-130-iso10646-1")
 
 (setq mac-emulate-three-button-mouse nil)
 


### PR DESCRIPTION
setup default font with 'set-frame-font', 'set-default-font' is obsolete since v23.1
