### PR TITLE
Rebind decrease-font-size to C-- instead of C-_.

### DIFF
--- a/bundles/accessibility/bundle.el
+++ b/bundles/accessibility/bundle.el
@@ -74,7 +74,7 @@
 
 (global-set-key (kbd "<f5>") 'ns-toggle-fullscreen)
 (global-set-key (kbd "C-+") 'increase-font-size)
-(global-set-key (kbd "C-_") 'decrease-font-size)
+(global-set-key (kbd "C--") 'decrease-font-size)
 
 ;; Highlight the current line
 (global-hl-line-mode t)


### PR DESCRIPTION
Most stock emacs installations bind Ctrl-underscore to `undo`, so it makes sense not to rebind such a commonly used key. I've changed the binding for `decrease-font-size` to Ctrl-minus (which makes sense, since the corresponding `increase-font-size` uses Ctrl-plus).
