### PR TITLE
Cleanup bindings after loading nxml- / html-modes.

### DIFF
--- a/lib/bundles.el
+++ b/lib/bundles.el
@@ -23,6 +23,7 @@
 (add-hook 'erlang-mode-hook 'e-max-clear-local-bindings)
 (add-hook 'diff-mode 'e-max-clear-local-bindings)
 (add-hook 'magit-mode 'e-max-clear-local-bindings)
+(add-hook 'html-mode-hook 'e-max-clear-local-bindings)
 
 (defun e-max-flymake-init ()
   "registered as hook in bundles ; configures flymake"


### PR DESCRIPTION
nxml-mode locally binds M-h to nxml-mark-paragraph, but the ergonomic bundle binds M-h to beginning-of-buffer, which should be globally available.
