### PR TITLE
functionality to deprecate a bundle (close #130)

### DIFF
--- a/bundles/html/bundle.el
+++ b/bundles/html/bundle.el
@@ -1,4 +1,4 @@
-(cabbage-bundle 'xml)
+(cabbage-load-bundle 'xml)
 
 
 (add-to-list 'auto-mode-alist '("\\.html$" . nxml-mode))

--- a/cabbage.el
+++ b/cabbage.el
@@ -39,7 +39,7 @@
 (run-hooks 'cabbage-pre-bundle-hook)
 
 (dolist (bundle cabbage-bundles)
-  (cabbage-bundle bundle))
+  (cabbage-load-bundle bundle))
 
 ;; TODO: load this earlier and debug the weird error
 (load (concat cabbage-repository "lib/themes"))

--- a/lib/bundles/framework.el
+++ b/lib/bundles/framework.el
@@ -1,4 +1,5 @@
 (defvar cabbage--globaly-bound-keys-alist '())
+(defvar cabbage--deprecated-bundles '("terminal"))
 
 (defun cabbage-bundle-active-p (bundle-name)
   (member bundle-name cabbage-bundles))
@@ -91,7 +92,7 @@ a value of nil means, this buffer does not contain an executable test")
          (message "Don't know what to do. Open an executable test and run again."))))
 
 
-(defun cabbage-bundle (bundle)
+(defun cabbage-load-bundle (bundle)
   "Load the given BUNDLE (which can be either a symbol or a string."
 
   (interactive (list (make-symbol
@@ -99,12 +100,20 @@ a value of nil means, this buffer does not contain an executable test")
                        "Bundle: "
                        (cabbage-bundles--list-available)))))
 
-  (load (concat cabbage-bundle-dir
-                (if (symbolp bundle)
-                    (symbol-name bundle) bundle)
-                "/bundle"))
-  (add-to-list 'cabbage-bundles bundle))
+  (let ((bundle-name (cabbage--bundle-name bundle)))
+    (when (member bundle-name cabbage--deprecated-bundles)
+      (warn (concat "the bundle '" bundle-name "' is deprecated. We are planning to remove the bundle in future versions of cabbage")))
+    (load (cabbage--bundle-path bundle))
+    (add-to-list 'cabbage-bundles bundle)))
 
+(defun cabbage--bundle-name (symbol-or-string)
+  (if (symbolp symbol-or-string)
+      (symbol-name bundle) symbol-or-string))
+
+(defun cabbage--bundle-path (bundle-name)
+  (concat cabbage-bundle-dir
+          (cabbage--bundle-name bundle-name)
+          "/bundle"))
 
 (defun cabbage-list-bundles ()
   "Show available and enabled list of bundles"


### PR DESCRIPTION
simple mechanics to deprecate a bundle. Whenever a deprecated bundle is loaded, e-max displays a warning buffer.
