### PR TITLE
rect-mark: move key binding definitions into ergonomic bundle

### DIFF
--- a/bundles/ergonomic/bundle.el
+++ b/bundles/ergonomic/bundle.el
@@ -154,3 +154,12 @@
 ;; TODO: find a suitable binding to use the search ring
 ;; (define-key isearch-mode-map (kbd "C-i") 'isearch-ring-retreat)
 ;; (define-key isearch-mode-map (kbd "C-k") 'isearch-ring-advance)
+
+;; rect-mark bindings
+(when (cabbage-bundle-active-p 'rect-mark)
+  (cabbage-global-set-key (kbd "C-x r M-SPC") 'rm-set-mark)
+  (cabbage-global-set-key (kbd "M-x") 'cabbage-kill-region-or-rm-kill-region-executor)
+  (cabbage-global-set-key (kbd "M-c") 'cabbage-kill-ring-save-or-rm-kill-ring-save-executor)
+  (cabbage-global-set-key (kbd "C-x r M-r") 'cabbage-replace-replace-string)
+  (cabbage-global-set-key (kbd "C-x r s") 'string-rectangle)
+  (cabbage-global-set-key (kbd "C-x r <down-mouse-1>") 'rm-mouse-drag-region))

--- a/bundles/rect-mark/bundle.el
+++ b/bundles/rect-mark/bundle.el
@@ -40,10 +40,3 @@
   (if rm-mark-active
       (call-interactively 'rm-kill-ring-save)
     (call-interactively 'kill-ring-save)))
-
-(cabbage-global-set-key (kbd "C-x r M-SPC") 'rm-set-mark)
-(cabbage-global-set-key (kbd "M-x")  'cabbage-kill-region-or-rm-kill-region-executor)
-(cabbage-global-set-key (kbd "M-c")  'cabbage-kill-ring-save-or-rm-kill-ring-save-executor)
-(cabbage-global-set-key (kbd "C-x r M-r")   'cabbage-replace-replace-string)
-(cabbage-global-set-key (kbd "C-x r s")     'string-rectangle)
-(cabbage-global-set-key (kbd "C-x r <down-mouse-1>") 'rm-mouse-drag-region)


### PR DESCRIPTION
this is a fix for #146
