### PR TITLE
move all cabbage global key bindings out of bundles into ergonomic

### DIFF
--- a/bundles/accessibility/bundle.el
+++ b/bundles/accessibility/bundle.el
@@ -77,10 +77,5 @@
   (if (cabbage-bundle-active-p 'maximize)
       (maximize-frame)))
 
-(global-set-key (kbd "<f5>") 'ns-toggle-fullscreen)
-(global-set-key (kbd "C-+") 'increase-font-size)
-(global-set-key (kbd "C--") 'decrease-font-size)
-(global-set-key (kbd "C-c C-w") 'whitespace-mode)
-
 ;; Highlight the current line
 (global-hl-line-mode t)

--- a/bundles/cabbage-developer/bundle.el
+++ b/bundles/cabbage-developer/bundle.el
@@ -9,6 +9,3 @@
   "Opens the cabbage perspective."
   (interactive)
   (cabbage-persp "@cabbage"))
-
-(global-set-key (kbd "C-c p") 'cabbage-emdeveloper-find-cabbage-config)
-(global-set-key (kbd "C-p e") 'cabbage-emdeveloper-emacs-persp)

--- a/bundles/completion/bundle.el
+++ b/bundles/completion/bundle.el
@@ -59,11 +59,5 @@ function in the chosen completion framework."
 ;;;; Smex Completion for M-x
 (smex-initialize)
 
-(defun cabbage-smex-bind-keys ()
-  (when (cabbage-bundle-active-p 'ergonomic)
-    (global-unset-key (kbd "M-a"))
-    (global-set-key (kbd "M-a") 'smex)))
-(add-hook 'cabbage-initialized-hook 'cabbage-smex-bind-keys)
-
 ;;;; Global IDO Completion
 (ido-everywhere t)

--- a/bundles/ergonomic/bundle.el
+++ b/bundles/ergonomic/bundle.el
@@ -155,7 +155,9 @@
 ;; (define-key isearch-mode-map (kbd "C-i") 'isearch-ring-retreat)
 ;; (define-key isearch-mode-map (kbd "C-k") 'isearch-ring-advance)
 
-;; rect-mark bindings
+;;;; Global bindings for cabbage bundles
+
+;; rect-mark bundle bindings
 (when (cabbage-bundle-active-p 'rect-mark)
   (cabbage-global-set-key (kbd "C-x r M-SPC") 'rm-set-mark)
   (cabbage-global-set-key (kbd "M-x") 'cabbage-kill-region-or-rm-kill-region-executor)
@@ -163,3 +165,65 @@
   (cabbage-global-set-key (kbd "C-x r M-r") 'cabbage-replace-replace-string)
   (cabbage-global-set-key (kbd "C-x r s") 'string-rectangle)
   (cabbage-global-set-key (kbd "C-x r <down-mouse-1>") 'rm-mouse-drag-region))
+
+;; irc bundle bindings
+(when (cabbage-bundle-active-p 'irc)
+  (cabbage-global-set-key (kbd "C-p i") 'cabbage-erc))
+
+;; jabber bundle bindings
+(when (cabbage-bundle-active-p 'jabber)
+  (cabbage-global-set-key (kbd "C-p j") 'cabbage-jabber))
+
+;; plone bundle bindings
+(when (cabbage-bundle-active-p 'plone)
+  (cabbage-global-set-key (kbd "C-c f c") 'cabbage-plone-find-changelog-make-entry)
+  (cabbage-global-set-key (kbd "M-T") 'cabbage-plone-find-file-in-package)
+  (cabbage-global-set-key (kbd "C-p b") 'cabbage-plone-ido-find-buildout)
+  (cabbage-global-set-key (kbd "C-c f r") 'cabbage-plone-reload-code)
+  (cabbage-global-set-key (kbd "C-c f f") 'cabbage-plone-run)
+  (cabbage-global-set-key (kbd "C-c f t") 'cabbage-plone-tests)
+  (cabbage-global-set-key (kbd "C-c f p") 'cabbage-plone--pep8-package))
+
+;; cabbage-developer bundle bindings
+(when (cabbage-bundle-active-p 'cabbage-developer)
+  (cabbage-global-set-key (kbd "C-c p") 'cabbage-emdeveloper-find-cabbage-config)
+  (cabbage-global-set-key (kbd "C-p e") 'cabbage-emdeveloper-emacs-persp))
+
+;; textmate bundle bindings
+(when (cabbage-bundle-active-p 'textmate)
+  (cabbage-global-set-key (kbd "M-<up>") 'move-text-up)
+  (cabbage-global-set-key (kbd "M-<down>") 'move-text-down)
+  (cabbage-global-set-key (kbd "M-<right>")  'textmate-shift-right)
+  (cabbage-global-set-key (kbd "M-<left>") 'textmate-shift-left))
+
+;; accessibility bundle bindings
+(when (cabbage-bundle-active-p 'accessibility)
+  (cabbage-global-set-key (kbd "<f5>") 'ns-toggle-fullscreen)
+  (cabbage-global-set-key (kbd "C-+") 'increase-font-size)
+  (cabbage-global-set-key (kbd "C--") 'decrease-font-size)
+  (cabbage-global-set-key (kbd "C-c C-w") 'whitespace-mode))
+
+;; project bundle bindings
+(when (cabbage-bundle-active-p 'project)
+  (cabbage-global-set-key (kbd "M-t") 'textmate-goto-file)
+  (cabbage-global-set-key (kbd "M-w") 'textmate-goto-symbol)
+  (cabbage-global-set-key (kbd "C-x p") 'cabbage-project-ido-find-project))
+
+;; terminal bundle bindings
+(when (cabbage-bundle-active-p 'terminal)
+  (cabbage-global-set-key (kbd "C-p t") 'cabbage-terminal-open-term-persp)
+  (cabbage-global-set-key (kbd "C-x t n") 'multi-term)
+  (cabbage-global-set-key (kbd "C-x t t") 'multi-term-dedicated-toggle))
+
+;; org bundle bindings
+(when (cabbage-bundle-active-p 'org)
+  (cabbage-global-set-key (kbd "C-p o") 'cabbage-org-emacs-persp))
+
+;; git bundle bindings
+(when (cabbage-bundle-active-p 'git)
+  (cabbage-global-set-key (kbd "C-x g") 'magit-status))
+
+;; completion bundle bindings
+(when (cabbage-bundle-active-p 'completion)
+  (global-unset-key (kbd "M-a"))
+  (cabbage-global-set-key (kbd "M-a") 'smex))

--- a/bundles/git/bundle.el
+++ b/bundles/git/bundle.el
@@ -15,6 +15,3 @@
 (defun vc-git-annotate-command (file buf &optional rev)
   (let ((name (file-relative-name file)))
     (vc-git-command buf 0 name "blame" "-w" rev)))
-
-
-(global-set-key (kbd "C-x g") 'magit-status)

--- a/bundles/irc/bundle.el
+++ b/bundles/irc/bundle.el
@@ -1,4 +1,3 @@
-
 (defun cabbage-erc ()
   "Start erc in a seperate perspective."
   (interactive)
@@ -9,5 +8,3 @@
     (if (erc-server-buffer)
         (erc-cmd-RECONNECT)
       (call-interactively 'erc))))
-
-(cabbage-global-set-key (kbd "C-p i") 'cabbage-erc)

--- a/bundles/jabber/bundle.el
+++ b/bundles/jabber/bundle.el
@@ -1,4 +1,3 @@
-
 (defun cabbage-jabber ()
   "Open jabber in the @Jabber perspective."
   (interactive)
@@ -10,5 +9,3 @@
   (when (not (equal (substring (buffer-name) 0 8) "*-jabber"))
     (call-interactively 'jabber-display-roster)
     (switch-to-buffer jabber-roster-buffer)))
-
-(cabbage-global-set-key (kbd "C-p j") 'cabbage-jabber)

--- a/bundles/org/bundle.el
+++ b/bundles/org/bundle.el
@@ -33,8 +33,6 @@
 (add-hook 'org-after-todo-statistics-hook 'org-summary-todo)
 (add-hook 'org-mode-hook 'cabbage-org-mode-hook)
 
-(global-set-key (kbd "C-p o") 'cabbage-org-emacs-persp)
-
 (eval-after-load 'org
   '(progn
      (define-key org-mode-map (kbd "C-c a") 'org-agenda)

--- a/bundles/plone/buildout.el
+++ b/bundles/plone/buildout.el
@@ -130,8 +130,7 @@ script in this buildout"
           (compilation-start command 'python-pep8-mode))
 
         (message "No bin/pep8 found.")))
-
-    (cabbage-global-set-key (kbd "C-c f p") 'cabbage-plone--pep8-package)))
+    ))
 
 
 (add-hook 'cabbage-initialized-hook 'cabbage-plone--load-local-configuration)

--- a/bundles/plone/bundle.el
+++ b/bundles/plone/bundle.el
@@ -225,12 +225,3 @@ then prompts for a file. Expects to be within a package
     (yas/reload-all)))
 
 (add-hook 'python-mode-hook 'cabbage-plone--init-snippets)
-
-;; global bindings
-
-(cabbage-global-set-key (kbd "C-c f c") 'cabbage-plone-find-changelog-make-entry)
-(cabbage-global-set-key (kbd "M-T") 'cabbage-plone-find-file-in-package)
-(cabbage-global-set-key (kbd "C-p b") 'cabbage-plone-ido-find-buildout)
-(cabbage-global-set-key (kbd "C-c f r") 'cabbage-plone-reload-code)
-(cabbage-global-set-key (kbd "C-c f f") 'cabbage-plone-run)
-(cabbage-global-set-key (kbd "C-c f t") 'cabbage-plone-tests)

--- a/bundles/power-edit/bundle.el
+++ b/bundles/power-edit/bundle.el
@@ -55,10 +55,6 @@
     (switch-to-buffer buffer)))
 
 (cabbage-vendor 'textmate)
-(global-set-key (kbd "M-<up>") 'move-text-up)
-(global-set-key (kbd "M-<down>") 'move-text-down)
-(global-set-key (kbd "M-<right>")  'textmate-shift-right)
-(global-set-key (kbd "M-<left>") 'textmate-shift-left)
 
 ;; Do not cabbage-global-set-key TAB because this would override local
 ;; bindings such as in magit.

--- a/bundles/project/bundle.el
+++ b/bundles/project/bundle.el
@@ -32,10 +32,4 @@
     (let ((default-directory (concat cabbage-project-location project-name)))
       (call-interactively cabbage-project-find-file-function))))
 
-
-(global-set-key (kbd "C-x p") 'cabbage-project-ido-find-project)
-
-
 (cabbage-vendor 'textmate)
-(global-set-key (kbd "M-t") 'textmate-goto-file)
-(global-set-key (kbd "M-w") 'textmate-goto-symbol)

--- a/bundles/terminal/bundle.el
+++ b/bundles/terminal/bundle.el
@@ -65,13 +65,6 @@ cabbage bindings.")
                                        "C-d"
                                        ))))
 
-;; terminal bindings
-
-(when (cabbage-bundle-active-p 'ergonomic)
-  (cabbage-global-set-key (kbd "C-p t") 'cabbage-terminal-open-term-persp))
-(cabbage-global-set-key (kbd "C-x t n") 'multi-term)
-(cabbage-global-set-key (kbd "C-x t t") 'multi-term-dedicated-toggle)
-
 ;; funs
 
 (defun cabbage-terminal-open-term-persp ()


### PR DESCRIPTION
Moved all global key bindings out into the ergonomic bundle and startet emacs without the ergonomic bundle. All worked fine without any error messages, maybe @senny @jone .... try it out by you're self before merging it.

cheers
