### PR TITLE
Add more bindings for moving text around (power-edit bundle, C-M-<i/j/k/l>).

### DIFF
--- a/bundles/ergonomic/bundle.el
+++ b/bundles/ergonomic/bundle.el
@@ -193,9 +193,13 @@
 (when (cabbage-bundle-active-p 'power-edit)
   (cabbage-global-set-key (kbd "C-c SPC") 'ace-jump-mode)
   (cabbage-global-set-key (kbd "M-<up>") 'move-text-up)
+  (cabbage-global-set-key (kbd "C-M-i") 'move-text-up)
   (cabbage-global-set-key (kbd "M-<down>") 'move-text-down)
+  (cabbage-global-set-key (kbd "C-M-k") 'move-text-down)
   (cabbage-global-set-key (kbd "M-<right>")  'textmate-shift-right)
-  (cabbage-global-set-key (kbd "M-<left>") 'textmate-shift-left))
+  (cabbage-global-set-key (kbd "C-M-l")  'textmate-shift-right)
+  (cabbage-global-set-key (kbd "M-<left>") 'textmate-shift-left)
+  (cabbage-global-set-key (kbd "C-M-j") 'textmate-shift-left))
 
 ;; accessibility bundle bindings
 (when (cabbage-bundle-active-p 'accessibility)


### PR DESCRIPTION
`C-M-<i/j/k/l>` was not bound globally before, as far as I see.
The improvement is that it is no longer necessary to move the hand to the cursor keys for moving text around ;)
Yes, I'm lazy.

I'm not sure why moving text is / was only available when power-edit is activated..
