### PR TITLE
Plone bundle: fix crashing when findings file in a plone package with `M-t`.

### DIFF
--- a/bundles/plone/bundle.el
+++ b/bundles/plone/bundle.el
@@ -240,3 +240,13 @@ then prompts for a file. Expects to be within a package
     (yas/reload-all)))
 
 (add-hook 'python-mode-hook 'cabbage-plone--init-snippets)
+
+
+(defadvice textmate-goto-file (around textmate-goto-file-in-buildout activate)
+  "Change `textmate-goto-file' to ignore files as src/* bin/* of a package
+when within a buildout environment."
+  ;; Only use reduced find-file implementation when we are in a buildout
+  ;; environment.
+  (if (cabbage-plone--find-buildout-root default-directory)
+      (cabbage-plone--find-file-in-package (textmate-project-root))
+    ad-do-it))


### PR DESCRIPTION
Sometimes emacs crashes when doing a `M-t` in (plone) packages where a buildout was run within the package.
The problem is that we may have other sources within a nested src package and also a zope and a plone. These are too many files.

Filtering globally does not work because of similar directory names (we want to see the one "src" directory but not other). The solution is to filter those directories locally.

I've added `cabbage-plone--find-file-in-package`, which reimplements parts of the `M-t` so that we can change the ignores on the fly.

I've added an advice to `textmate-goto-file` which switches to the other implementation with more filters if we are in a buildout context.

@senny I it is not changing anything when not in a buildout context (and does not even advice when the plone bundle is not loaded), therefore I consider it save.
Do you have any objections or tips how to do this better?

It is a little bit hacky, but it is really annoying when emacs goes into "strand ball mode" - and I have no other idea how to fix this. :/
