### PR TITLE
New version of emacs-eclim & completion setup stuff

### DIFF
--- a/bundles/java/bundle.el
+++ b/bundles/java/bundle.el
@@ -1,46 +1,8 @@
 
-(defcustom cabbage-java-use-eclim t
-  "Use eclim for managing java files."
-  :type 'boolean
-  :group 'cabbage)
-
 (defun cabbage-java-init ()
   "Initialize the java bundle."
 
   (cabbage-vendor 'java-mode-indent-annotations)
-  (add-hook 'java-mode-hook 'java-mode-indent-annotations-setup)
-
-  (when cabbage-java-use-eclim
-    (add-to-list 'load-path (concat (cabbage-vendor-library-dir 'eclim)
-                                    "vendor/"))
-    (cabbage-vendor 'eclim)
-
-    (setq eclim-interactive-completion-function 'ido-completing-read)
-
-    (setq help-at-pt-display-when-idle t)
-    (setq help-at-pt-timer-delay 0.1)
-    (help-at-pt-set-timer)
-
-    (global-eclim-mode t)
-
-    (case cabbage-completion-framework
-      ('auto-complete
-       (require 'ac-emacs-eclim-source)
-       (add-hook 'eclim-mode-hook (lambda ()
-                                    (add-to-list 'ac-sources 'ac-source-emacs-eclim)
-                                    (add-to-list 'ac-sources 'ac-source-emacs-eclim-c-dot))))
-      ('company-mode
-       (require 'company-emacs-eclim)
-       (company-emacs-eclim-setup)))
-
-    ;; If we are using the snippets bundle, append the eclim
-    ;; yasnippets dir to the list of yasnippet directories
-    (if (and eclim-use-yasnippet (cabbage-bundle-active-p 'snippets))
-        (add-hook 'cabbage-initialized-hook
-                  (lambda ()
-                    (let ((dir (concat (cabbage-vendor-library-dir 'eclim)
-                                       "snippets/")))
-                      (add-to-list 'yas/root-directory dir t)
-                      (yas/load-directory dir)))))))
+  (add-hook 'java-mode-hook 'java-mode-indent-annotations-setup))
 
 (cabbage-java-init)

--- a/vendor/java-mode-indent-annotations/java-mode-indent-annotations.el
+++ b/vendor/java-mode-indent-annotations/java-mode-indent-annotations.el
@@ -26,7 +26,7 @@
 
 
 ;;; Commentary:
-;; 
+;;
 ;; This library tries to indent java annotations
 ;; (http://java.sun.com/j2se/1.5.0/docs/guide/language/annotations.html)
 ;; like the code examples listed in the webpage.
@@ -69,6 +69,7 @@ This function should be called from a java or jde mode hook,
 after any calls to `c-set-style'."
   (c-preprend-offset 'arglist-intro 'c-single-indent-after-java-annotations)
   (c-preprend-offset 'topmost-intro-cont 'c-no-indent-after-java-annotations)
+  (c-preprend-offset 'annotation-var-cont 'c-no-indent-after-java-annotations)
   (c-preprend-offset 'arglist-close 'c-no-indent-after-java-annotations)
   (c-preprend-offset 'statement-cont 'c-no-indent-after-java-annotations)
   (c-preprend-offset 'func-decl-cont 'c-no-indent-after-java-annotations))


### PR DESCRIPTION
Hi, I've reworked the completion code in emacs-eclim, and correspondingly updated the version in cabbage.

Also, an older change which fixed indenting of certain methods in java code seems to have snuck in as well.
