### PR TITLE
Improved project API

### DIFF
--- a/lib/bundles/framework.el
+++ b/lib/bundles/framework.el
@@ -63,6 +63,14 @@
           ((> (length (intersection present-files cabbage-project-root-indicators :test 'string=)) 0) directory)
           (t (cabbage-project-root (file-name-directory (directory-file-name directory)))))))
 
+(defun cabbage-project-expand-path (&rest segments)
+  "Construct a path relative to the cabbage-project-root"
+  (let ((project-root (cabbage-project-root)))
+    (when (not project-root) (error "Could not detect project root"))
+    (let ((path (mapconcat 'identity segments "/"))
+          (installation-dir (replace-regexp-in-string "/$" "" project-root)))
+      (expand-file-name (concat installation-dir "/" path)))))
+
 ;; API: integrated testing
 (defvar cabbage-testing--last-project-root nil
   "cache for the project-root of the last executed spec-file")


### PR DESCRIPTION
#### 1.) bugfix if `default-directory` is "~/"

This resulted in an endless loop. We now expand the path to git rid of this edge-case.
#### 2.) `(cabbage-project-p)` checks if a project is found

This is a simple function to check if cabbage can detect a project or not. It must be used as a guard to prevent calls into the project API when no root can be found.
#### 3.) `(cabbage-project-expand-path)` builds relative project paths.

This function is similar to Emacs `expand-path` with the difference that it builds relative paths to the current `(cabbage-project-root)`. Note that this function throws an error when no `(cabbage-project-root)` can be found.
