### PR TITLE
changed git to https url for submodule ido-ubiquitous, closes #190

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -115,7 +115,7 @@
 
 [submodule "vendor/ido-ubiquitous"]
 	path = vendor/ido-ubiquitous
-	url = git://github.com/DarwinAwardWinner/ido-ubiquitous.git
+	url = https://github.com/DarwinAwardWinner/ido-ubiquitous.git
 [submodule "vendor/ace-jump-mode"]
 	path = vendor/ace-jump-mode
 	url = https://github.com/winterTTr/ace-jump-mode.git


### PR DESCRIPTION
Closes #190 

Hi

This should resolve the issue #190 (git:// url could get blocked by corporate firewalls). Also all other submodule url's are https://.

Thanks,
Raphael
