### PR TITLE
new function to run a single ruby test-file.

### DIFF
--- a/bundles/ruby/bundle.el
+++ b/bundles/ruby/bundle.el
@@ -5,6 +5,11 @@
   :type 'boolean
   :group 'cabbage)
 
+(defcustom cabbage-ruby-test-ruby-options '("-Itest")
+  "Options to pass to ruby when executing a test file."
+  :type 'string
+  :group 'cabbage)
+
 ;;;; -------------------------------------
 ;;;; Bundle
 
@@ -42,13 +47,14 @@
   (interactive (list(buffer-file-name)))
   (let* ((name-buffer "ruby-test")
          (name-buffer-full (format "*%s*" name-buffer))
-         (project-root (cabbage-project-root (file-name-directory filename))))
+         (project-root (cabbage-project-root (file-name-directory filename)))
+         (command-list (cons "ruby" (append cabbage-ruby-test-ruby-options (list filename)))))
     (display-buffer (get-buffer-create name-buffer-full))
     (with-current-buffer name-buffer-full
       (setq default-directory project-root)
       (erase-buffer))
     (display-buffer name-buffer-full)
-    (ruby-compilation-do name-buffer (cons "ruby" (list filename)))))
+    (ruby-compilation-do name-buffer command-list)))
 
 (defun cabbage-open-spec-other-buffer ()
   (interactive)


### PR DESCRIPTION
Key concepts:
- no buffer flickering
- no buffer switching
- clear after each run
- support minitest and test-unit

Work to do:
- [x] don't switch to the test output buffer when executing a test
- [x] the test buffer should stay at the same place once it is open
- [x] set the `default-directory` to the project root of the last executed test
- [x] fix blank test output windows

> Was caused by a bug in `trunk` and is not related to the code of this PR
- [x] support test-suites that don't use `require_relative` and need the test directory in the `LOAD_PATH`

> `cabbage-ruby-test-ruby-options` allows to pass options to `ruby` and defaults to `-Itest`
- [x] support test-suites that need to pass environment variables

> Can be achieved using `(setenv "ENV" "VALUE")`
- [ ] somehow detect if `_spec.rb` is rspec or `Minitest::Spec`. Not sure how though...
