### PR TITLE
js/coffee based erb files autoloads the specific language mode

### DIFF
--- a/bundles/coffee-script/bundle.el
+++ b/bundles/coffee-script/bundle.el
@@ -1,6 +1,6 @@
 (cabbage-vendor 'coffee-mode)
 
-(add-to-list 'auto-mode-alist '("\\.coffee$" . coffee-mode))
+(add-to-list 'auto-mode-alist '("\\.coffee\\(\\.erb\\)?$" . js-mode))
 (add-to-list 'auto-mode-alist '("Cakefile" . coffee-mode))
 
 (defun cabbage-coffee-mode-hook ()

--- a/bundles/javascript/bundle.el
+++ b/bundles/javascript/bundle.el
@@ -14,8 +14,7 @@
 
 ;;;; -------------------------------------
 ;;;; Bundle
-(add-to-list 'auto-mode-alist '("\\.js\\(on\\)?$" . js-mode))
-
+(add-to-list 'auto-mode-alist '("\\.js\\(on\\|\\.erb\\)?$" . js-mode))
 
 ;; Defuns
 


### PR DESCRIPTION
@senny In my workaday I also using `*.js.erb` and legacy `.coffee.erb` :hankey: files. :-) I think the specific language mode should be also loaded with that file endings. 

Cheers